### PR TITLE
moved all scenes to match their day label

### DIFF
--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_Conference.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_Conference.ink
@@ -8,7 +8,7 @@ VAR HappyBrad = true
 # date.day!5
 # @end
 # repeatable: false
-# tags: action, lecture_hall
+# tags: action, lecture_hall, required
 # ===
 # Summary: Brad discusses rejected paper/confronted about IRB stuff w/ Ned, talks to Bronislav about Jensen being on paper
 

--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_ConferenceSubmissionDeadline.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_ConferenceSubmissionDeadline.ink
@@ -6,7 +6,7 @@
 # @end
 # hidden: true
 # repeatable: false
-# tags: action, student_cubes
+# tags: action, student_cubes, auxiliary
 # ===
 # Summary: Brad confides in Bronislav about using pre-IRB data
 

--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_LabMeeting.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_LabMeeting.ink
@@ -1,13 +1,13 @@
 VAR withdrewPaper = false
 
 === BB_LabMeeting_SceneStart ===
-#---
-#choiceLabel: Sit and relax.
-#@query
+# ---
+# choiceLabel: Sit and relax.
+# @query
 # date.day!6
-#@end.
-#repeatable: false
-#tags: action, student_cubes
+# @end
+# repeatable: false
+# tags: action, student_cubes, auxiliary
 #===
 #Summary: Brad either goes to ethics training or shares excitement about next conference
 

--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing1.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing1.ink
@@ -1,12 +1,12 @@
 === BB_Socializing1_SceneStart ===
-#---
+# ---
 # choiceLabel: Go to your cube.
-#@query
+# @query
 # date.day!1
 # @end
 # repeatable: false
-# tags: action, student_cubes
-#===
+# tags: action, student_cubes, required
+# ===
 
 // Summary: You meet Brad and he expresses stress for the IRB not getting back to him. If you are good enough relationship he tells you about his concern about Jensen
 

--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing4.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing4.ink
@@ -1,15 +1,15 @@
 VAR confided = false
 
 === BB_Socializing4_SceneStart ===
-#---
-#choiceLabel: Wait for Brad.
-#@query
+# ---
+# choiceLabel: Wait for Brad.
+# @query
 # date.day!4
-#@end.
-#repeatable: false
-#tags: action, library
-#===
-#Summary: Brad is contemplating withdrawing paper
+# @end
+# repeatable: false
+# tags: action, library, auxiliary
+# ===
+# Summary: Brad is contemplating withdrawing paper
 
 {DbInsert("Seen_BBS4")}
 

--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing6.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing6.ink
@@ -1,15 +1,14 @@
 VAR withdrewPaperr = false
 
 === BB_Socializing6_SceneStart ===
-#---
-#choiceLabel: Wait for Brad.
-#@query
+# ---
+# choiceLabel: Wait for Brad.
+# @query
 # date.day!6
-#
-#@end.
-#repeatable: false
-#tags: action, cafe
-#===
+# @end
+# repeatable: false
+# tags: action, cafe, auxiliary
+# ===
 # Summary: Ned and Brad overlook the outcome of the options
 
 // show seen if Brad withdrew paper

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing1.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing1.ink
@@ -22,7 +22,7 @@ She wants to talk about your research progress.
 # BHS1_unlocked
 # date.day!1
 # @end
-# tags: action, library, auxiliary
+# tags: action, library, required
 # repeatable: false
 # ===
 

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing2.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing2.ink
@@ -4,6 +4,7 @@
 # choiceLabel: Meet with Hendricks.
 # @query
 # Seen_BHS1
+# date.day!2
 # @end
 # tags: action, library, auxiliary
 # repeatable: false

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing3.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing3.ink
@@ -4,6 +4,7 @@
 # choiceLabel: Find Hendricks in the Library
 # @query
 # Seen_BHS2
+# date.day!3
 # @end
 # tags: action, library, auxiliary
 # repeatable: false

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing4.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing4.ink
@@ -31,7 +31,7 @@ VAR BHS4_tension = 0
 # AcceptedIvyDeal
 # date.day!4
 # @end
-# tags: hendricks_office, auxiliary
+# tags: action, hendricks_office, auxiliary
 # ---
 
 You knock Hendricks' office door.

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing5.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing5.ink
@@ -1,12 +1,12 @@
 === BH_Socializing5_SceneStart ===
-#---
-#choiceLabel: Peruse library.
-#@query
+# ---
+# choiceLabel: Peruse library.
+# @query
 # date.day!5
-#@end.
-#repeatable: false
-#tags: action, library
-#===
+# @end
+# repeatable: false
+# tags: action, library, required
+# ===
 
 // current default is took the deal
 Today has been going incredibly well, and the excitement of your upcoming job came with a sense of accomplishment. 

--- a/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing6.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Hendricks/BH_Socializing6.ink
@@ -1,12 +1,12 @@
 === BH_Socializing6_SceneStart ===
-#---
-#choiceLabel: Speak with Hendricks.
-#@query
+# ---
+# choiceLabel: Speak with Hendricks.
+# @query
 # date.day!6
-#@end.
-#repeatable: false
-#tags: action, hendricks_office
-#===
+# @end
+# repeatable: false
+# tags: action, hendricks_office, auxiliary
+# ===
 
 //TODO: Create a variable to see if Bronislav took the quid pro quo deal
 

--- a/Assets/InkScripts/Bronislav/Bron&Ivy/BI_Socializing5.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Ivy/BI_Socializing5.ink
@@ -1,11 +1,11 @@
 === BI_Socializing5_SceneStart ===
-#---
-#choiceLabel: Meet with Ivy.
-#@query
+# ---
+# choiceLabel: Meet with Ivy.
+# @query
 # date.day!5
-#@end.
-#repeatable: false
-#tags: action, cafe
+# @end
+# repeatable: false
+# tags: action, cafe, required
 #===
 
 // TODO: selection based off of whether Jensen was ever on the paper

--- a/Assets/InkScripts/Bronislav/Bron&Jen/BJ_Socializing5.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Jen/BJ_Socializing5.ink
@@ -16,7 +16,7 @@ library after ... <TODO:: WHEN DOES THIS HAPPEN??>.
 # date.day!5
 # @end
 # hidden: true
-# tags: action, library, auxiliary
+# tags: action, library, required
 # ===
 # Summary: Jensen asks to meet at the conference to talk about his feelings of the outcome. 
 

--- a/Assets/InkScripts/Bronislav/Bron&Ned/BN_LabMeeting.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Ned/BN_LabMeeting.ink
@@ -3,10 +3,11 @@
 # choiceLabel: Meet with Ned in the Lab
 # @query
 # Seen_BNS1
+# date.day!6
 # @end
 # hidden: true
 # repeatable: false
-# tags: action, neds_office, auxiliary
+# tags: action, neds_office, required
 # ===
 
 {DbInsert("Seen_BNLM")}

--- a/Assets/InkScripts/Bronislav/Bron&Ned/BN_Socializing1.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Ned/BN_Socializing1.ink
@@ -7,7 +7,7 @@
 # @end
 # hidden: true
 # repeatable: false
-# tags: action, library, auxiliary
+# tags: action, library, required
 # ===
 
 {DbInsert("Seen_BNS1")}

--- a/Assets/InkScripts/Bronislav/Bron&Ned/BN_Socializing5.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Ned/BN_Socializing5.ink
@@ -2,14 +2,14 @@ VAR basicsLie = false
 VAR BradWithdrew = false
 
 === BN_Socializing5_SceneStart ===
-#---
-#choiceLabel: Drop in to talk with Ned.
-#@query
+# ---
+# choiceLabel: Drop in to talk with Ned.
+# @query
 # date.day!5
-#@end.
-#repeatable: false
-#tags: action, neds_office
-#===
+# @end.
+# repeatable: false
+# tags: action, neds_office, auxiliary
+# ===
 # Summary: Confronting Bronislav on what he knows about Brad's work
 
 VAR honesty = false

--- a/Assets/InkScripts/Bronislav/Bron&Praveen/BP_ConferenceSubmissionDeadline.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Praveen/BP_ConferenceSubmissionDeadline.ink
@@ -4,6 +4,7 @@
 # hidden: true
 # @query
 # Seen_BI_CONF
+# date.day!3
 # @end
 # tags: action, library, auxiliary
 # repeatable: false

--- a/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing2.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing2.ink
@@ -12,7 +12,7 @@ VAR BP_S2_AskDirectly = false
 # date.day!2
 # @end
 # hidden: true
-# tags: action, student_cubes, auxiliary, required
+# tags: action, student_cubes, required
 # repeatable: false
 #===
 

--- a/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing3.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing3.ink
@@ -1,13 +1,13 @@
 === BP_Socializing3_SceneStart ===
-#---
-#choiceLabel: Chat with Praveen.
-#@query
+# ---
+# choiceLabel: Chat with Praveen.
+# @query
 # date.day!3
 # Seen_BP_ConferenceSubmissionDeadline
-#@end.
-#repeatable: false
-#tags: action, student_cubicles
-#===
+# @end
+# repeatable: false
+# tags: action, student_cubicles
+# ===
 
 {DbInsert("Seen_BP_Socializing3")}
 

--- a/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing6.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Praveen/BP_Socializing6.ink
@@ -3,9 +3,10 @@
 # choiceLabel: Visit the Cafe and see Praveen
 # @query
 # Seen_BPS3
+# date.day!6
 # @end
 # hidden: true
-# tags: action, cafe, auxiliary
+# tags: action, cafe, required
 # ===
 
 {DbInsert("Seen_BPS6")}


### PR DESCRIPTION
# Description

We were having some characters be able to have all of their dialogues occur at once, or other characters wait on their dialogue for a late date that didn't make sense.

# Summary of changes

- Updated formatting on all tags/prereqs on inky files
- Updated query requirements to match date requirements
- Made most first and last encounters required for the play so that they see the intro/repercussions of a given storyline.