### PR TITLE
Intro scenes

### DIFF
--- a/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing1.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Brad/BB_Socializing1.ink
@@ -144,7 +144,7 @@ Brad: "It's just... it feels like the IRB has been taking a long time to approve
 *["They do take a bit."]
 ->BB_S1_TheyDoTakeABit
 
-*["Stressed about that?" #>> DecrtRelationshipStatus Brad Bronislav 10]
+*["Stressed about that?" #>> ChangeOpinion Brad Bronislav --]
 ->BB_S1_StressedAbtThat
 
 ==BB_S1_PaperExposition==
@@ -178,7 +178,7 @@ Brad: "Yeah, tell me about it. The IRB is taking forever to approve my research 
 *["They do take a bit."]
 ->BB_S1_TheyDoTakeABit
 
-*["Stressed about that?" #>> DecrtRelationshipStatus Brad Bronislav 10]
+*["Stressed about that?" #>> ChangeOpinion Brad Bronislav --]
 ->BB_S1_StressedAbtThat
 
 === BB_S1_CouldBeBetter ===
@@ -194,7 +194,7 @@ Brad: "It's just... it feels like the IRB has been taking a long time to approve
 *["They do take a bit."]
 ->BB_S1_TheyDoTakeABit
 
-*["Stressed about that?" #>> DecrtRelationshipStatus Brad Bronislav 10]
+*["Stressed about that?" #>> ChangeOpinion Brad Bronislav --]
 ->BB_S1_StressedAbtThat
 
 === BB_S1_SoundsStressful ===

--- a/Assets/InkScripts/Bronislav/Bron&Jen/BJ_Introduction.ink
+++ b/Assets/InkScripts/Bronislav/Bron&Jen/BJ_Introduction.ink
@@ -25,13 +25,38 @@ As Bronislav, you must chose how to approach this situation.
 {UnlockAllLocations()}
 {DbInsert("Seen_BJ_INTRO")}
 
-Today you are presenting a practice paper talk at the weekly psychology department seminar.
+You nervously approach the podium. The room has filled up with what seems like the entire department - Professors, undergrads, grads, admins.
 
-You go to the front of the room and speak for about 45 minutes.
+You go to the front of the room and speak for about 45 minutes. It starts off a little shaky, but you quickly get into the flow and feel confident by the end.
 
-Surprisingly, your peers seemed to enjoy your work. A few tough questions, but nothing you couldn't handle.
+Your peers seemed to enjoy your work. A few tough questions, but nothing you couldn't handle. It's a major relief after so many months of hard research and writing.
 
-Afterward, while packing up your laptop, someone approaches you, eager to talk.
+Afterward, while packing up your laptop, a line forms of people in the department to give their congratulations.
+
+{ShowCharacter("Hendricks", "left", "")}
+Hendricks: "Congratulations Bronislav! That was great - I'm so lucky to have such a great advisee!" 
+{HideCharacter("Hendricks")}
+
+{ShowCharacter("Brad", "left", "")}
+Brad: "That was so cool buddy! Our work together on this is paying off. I'll finish up the IRB paperwork ASAP!"
+{HideCharacter("Brad")}
+
+{ShowCharacter("Ned", "left", "")}
+Ned: "Heh, Brad seems excited about our work. I think this is all but guaranteed to get into the conference."
+{HideCharacter("Ned")}
+
+{ShowCharacter("Praveen", "left", "")}
+Praveen: "Wow, great stuff! So many people involved - I hope I can one day match your networking skills!"
+{HideCharacter("Praveen")}
+
+{ShowCharacter("Ivy", "left", "")}
+Ivy: "Such an impressive presentation. The department could use more of this! My nephew-"
+Ivy: "...Ahem, oops! I meant to say undergrad mentee. Sorry about that! Anyways, they wanted to talk to you - keep an ear out!"
+{HideCharacter("Ivy")}
+
+<i>(You can learn more about any character using the "Characters" button at the top of the screen.)</i>
+
+The room clears out. A final person, likely an undergrad, approaches you nervously.
 
 Jensen: "Bronislav, right? Nice to meet you. I'm Jensen." {ShowCharacter("Jensen", "left", "")}
 

--- a/Assets/InkScripts/Bronislav/DayIntros.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98e0b18e84b908541a87976811d3f878
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day1.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day1.ink
@@ -1,0 +1,10 @@
+=== day1 ===
+
+# ---
+# ===
+
+{ShowCharacter("Bronislav", "right", "")}
+
+This is a test of our emergency intro system.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day1.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day1.ink
@@ -3,8 +3,6 @@
 # ---
 # ===
 
-//TODO: This always starts with Bronislav rendered when it really shouldn't.
-
 Welcome to the world of Academical!
 
 

--- a/Assets/InkScripts/Bronislav/DayIntros/day1.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day1.ink
@@ -3,8 +3,37 @@
 # ---
 # ===
 
+//TODO: This always starts with Bronislav rendered when it really shouldn't.
+
+Welcome to the world of Academical!
+
+
+{ShowCharacter("Bronislav", "right", "")}
+This is you! Your name is Bronislav. 
+You are a PhD student in the final stretch of their dissertation. You are trying to finish out a final round of publications while maintaining your relationships with professors and peers in the Psychology department at your university.
+The stresses of your degree are getting to you - your Visa ends soon, and you need to find a job that will provide one shortly after graduation. You also need a few more peer-reviewed conference publications to demonstrate the quality of your dissertation.
+You are just starting a new quarter, and a major conference is coming up soon. Students and Faculty alike are rushing around trying to get their work submitted on time.
+Your job is to navigate through conversations and meetings with characters in the department throughout the upcoming term.
+
+{HideCharacter("Bronislav")}
+
+Before we start, some tips:
+The top of the screen has a row of buttons to help you manage your time in this world.
+The <i><b>"Pause"</b></i> button lets you change settings and take a break from the story.
+The <i><b>"Save"</b></i> button lets you save your progress so you can return at a later time.
+The <i><b>"History"</b></i> button shows a history of past dialogue you've encountered in the story.
+The <i><b>"Characters"</b></i> button shows information about each character as well as your current relationship status with them.
+The <i><b>"Dilemmas"</b></i> button shows what moral and relationship issues have arisen.
+The <i><b>"Agenda"</b></i> button shows what key events are planned for the upcoming term.
+Characters will be at various locations across campus during gameplay. The <i><b>"Choose Location"</i></b> button on the lower-right side of the screen allows you to go to various locations. Areas of interest will be represented with exclamation and question mark icons.
+Once in a location, the <i><b>"Choose Action"</i></b> button on the bottom-left will allow you to choose a specific character to interact with at a given location.
+With all of that out of the way, let's get started! 
+
+{SetPlayerLocation("lecture_hall")}
 {ShowCharacter("Bronislav", "right", "")}
 
-This is a test of our emergency intro system.
+It's the start of a new term - and you've (<i>mostly</i>) finished work on research that you aim to submit to a conference at the end of the term.
+
+Your department has agreed to watch a presentation of your work so that you can get feedback before your final submission.
 
 -> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day1.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day1.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7b155113582a16442ab0d4267eab9b4b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day2.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day2.ink
@@ -1,0 +1,3 @@
+=== day2 ===
+
+This is a test of the emergency broadcast system.

--- a/Assets/InkScripts/Bronislav/DayIntros/day2.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day2.ink
@@ -3,6 +3,6 @@
 # ---
 # ===
 
-This is a test of the emergency broadcast system.
+This is the introduction to day 2.
 
 -> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day2.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day2.ink
@@ -1,3 +1,8 @@
 === day2 ===
 
+# ---
+# ===
+
 This is a test of the emergency broadcast system.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day2.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day2.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c1f3b8a99be41004dbb6e0303521fef4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day3.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day3.ink
@@ -1,0 +1,8 @@
+=== day3 ===
+
+# ---
+# ===
+
+This is the introduction to day 3.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day3.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day3.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3318227230d3cb54e99ae70fa75c7d60
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day4.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day4.ink
@@ -1,0 +1,8 @@
+=== day4 ===
+
+# ---
+# ===
+
+This is the introduction to day 4.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day4.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day4.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9c641f62801f71f4ab1838a410f1542e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day5.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day5.ink
@@ -1,0 +1,8 @@
+=== day5 ===
+
+# ---
+# ===
+
+This is the introduction to day 5.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day5.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day5.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: acf5db11a1945474db644423a396de06
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/DayIntros/day6.ink
+++ b/Assets/InkScripts/Bronislav/DayIntros/day6.ink
@@ -1,0 +1,8 @@
+=== day6 ===
+
+# ---
+# ===
+
+This is the introduction to day 6.
+
+-> DONE

--- a/Assets/InkScripts/Bronislav/DayIntros/day6.ink.meta
+++ b/Assets/InkScripts/Bronislav/DayIntros/day6.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95170af50b4f3de42a388e5fb0ab690e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InkScripts/Bronislav/main.ink
+++ b/Assets/InkScripts/Bronislav/main.ink
@@ -69,6 +69,10 @@ INCLUDE ./Bron&Brad/BB_Conference.ink
 
 INCLUDE ./DayIntros/day1.ink
 INCLUDE ./DayIntros/day2.ink
+INCLUDE ./DayIntros/day3.ink
+INCLUDE ./DayIntros/day4.ink
+INCLUDE ./DayIntros/day5.ink
+INCLUDE ./DayIntros/day6.ink
 
 EXTERNAL DbInsert(statement)
 EXTERNAL DbAssert(statement)

--- a/Assets/InkScripts/Bronislav/main.ink
+++ b/Assets/InkScripts/Bronislav/main.ink
@@ -67,6 +67,7 @@ INCLUDE ./Bron&Brad/BB_Socializing4.ink
 INCLUDE ./Bron&Brad/BB_Socializing6.ink
 INCLUDE ./Bron&Brad/BB_Conference.ink
 
+INCLUDE ./DayIntros/day1.ink
 
 EXTERNAL DbInsert(statement)
 EXTERNAL DbAssert(statement)
@@ -90,10 +91,36 @@ EXTERNAL SetPlayerLocation(locationID)
 # ---
 # ===
 
-// Show the current player character on screen
-// (even when not in dialogue)
+{SetPlayerLocation("lecture_hall")}
+
+Welcome to the world of Academical!
+
 {ShowCharacter("Bronislav", "right", "")}
 
-{SetPlayerLocation("lecture_hall")}
+This is you! Your name is Bronislav. 
+You are a PhD student in the final stretch of their dissertation. You are trying to finish out a final round of publications while maintaining your relationships with professors and peers in the Psychology department at your university.
+The stresses of your degree are getting to you - your Visa ends soon, and you need to find a job that will provide one shortly after graduation. You also need a few more peer-reviewed conference publications to demonstrate the quality of your dissertation.
+You are just starting a new quarter, and a major conference is coming up soon. Students and Faculty alike are rushing around trying to get their work submitted on time.
+Your job is to navigate through conversations and meetings with characters in the department throughout the upcoming term.
+
+{HideCharacter("Bronislav")}
+
+Before we start, some tips:
+The top of the screen has a row of buttons to help you manage your time in this world.
+The "Pause" button lets you change settings and take a break from the story.
+The "Save" button lets you save your progress so you can return at a later time.
+The "History" button shows a history of past dialogue you've encountered in the story.
+The "Characters" button shows information about each character as well as your current relationship status with them.
+The "Dilemmas" button shows what moral and relationship issues have arisen.
+The "Agenda" button shows what key events are planned for the upcoming term.
+Characters will be at various locations across campus during gameplay. The "Choose Location" button on the lower-right side of the screen allows you to go to various locations. Areas of interest will be represented with exclamation and question mark icons.
+Once in a location, the "Choose Action" button on the bottom-left will allow you to choose a specific character to interact with at a given location.
+With all of that out of the way, let's get started! 
+
+{ShowCharacter("Bronislav", "right", "")}
+
+It's the start of a new term - and you've (mostly) finished work on research that you aim to submit to a conference at the end of the term.
+
+Your department has agreed to watch a presentation of your work so that you can get feedback before your final submission.
 
 -> DONE

--- a/Assets/InkScripts/Bronislav/main.ink
+++ b/Assets/InkScripts/Bronislav/main.ink
@@ -68,6 +68,7 @@ INCLUDE ./Bron&Brad/BB_Socializing6.ink
 INCLUDE ./Bron&Brad/BB_Conference.ink
 
 INCLUDE ./DayIntros/day1.ink
+INCLUDE ./DayIntros/day2.ink
 
 EXTERNAL DbInsert(statement)
 EXTERNAL DbAssert(statement)

--- a/Assets/InkScripts/Bronislav/main.ink
+++ b/Assets/InkScripts/Bronislav/main.ink
@@ -91,36 +91,4 @@ EXTERNAL SetPlayerLocation(locationID)
 # ---
 # ===
 
-{SetPlayerLocation("lecture_hall")}
-
-Welcome to the world of Academical!
-
-{ShowCharacter("Bronislav", "right", "")}
-
-This is you! Your name is Bronislav. 
-You are a PhD student in the final stretch of their dissertation. You are trying to finish out a final round of publications while maintaining your relationships with professors and peers in the Psychology department at your university.
-The stresses of your degree are getting to you - your Visa ends soon, and you need to find a job that will provide one shortly after graduation. You also need a few more peer-reviewed conference publications to demonstrate the quality of your dissertation.
-You are just starting a new quarter, and a major conference is coming up soon. Students and Faculty alike are rushing around trying to get their work submitted on time.
-Your job is to navigate through conversations and meetings with characters in the department throughout the upcoming term.
-
-{HideCharacter("Bronislav")}
-
-Before we start, some tips:
-The top of the screen has a row of buttons to help you manage your time in this world.
-The "Pause" button lets you change settings and take a break from the story.
-The "Save" button lets you save your progress so you can return at a later time.
-The "History" button shows a history of past dialogue you've encountered in the story.
-The "Characters" button shows information about each character as well as your current relationship status with them.
-The "Dilemmas" button shows what moral and relationship issues have arisen.
-The "Agenda" button shows what key events are planned for the upcoming term.
-Characters will be at various locations across campus during gameplay. The "Choose Location" button on the lower-right side of the screen allows you to go to various locations. Areas of interest will be represented with exclamation and question mark icons.
-Once in a location, the "Choose Action" button on the bottom-left will allow you to choose a specific character to interact with at a given location.
-With all of that out of the way, let's get started! 
-
-{ShowCharacter("Bronislav", "right", "")}
-
-It's the start of a new term - and you've (mostly) finished work on research that you aim to submit to a conference at the end of the term.
-
-Your department has agreed to watch a presentation of your work so that you can get feedback before your final submission.
-
--> DONE
+-> day1

--- a/Assets/Resources/LocationDatabase.asset
+++ b/Assets/Resources/LocationDatabase.asset
@@ -69,3 +69,11 @@ MonoBehaviour:
     connectedLocations: []
     defaultBackground: {fileID: 21300000, guid: eca51147b940048bd829177c326bc221, type: 3}
     lockConditions: []
+  - displayName: Unspecified
+    uid: unspecified
+    nameColor: {r: 0, g: 0, b: 0, a: 0}
+    sprite: {fileID: 0}
+    bio: 'Container for storylets that are '
+    connectedLocations: []
+    defaultBackground: {fileID: 21300000, guid: eca51147b940048bd829177c326bc221, type: 3}
+    lockConditions: []

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2917,6 +2917,7 @@ MonoBehaviour:
   m_Player: {fileID: 1596147016}
   m_simulationController: {fileID: 369746412}
   m_socialEngine: {fileID: 369746416}
+  m_backgroundOverlay: {fileID: 6294589840691571660}
   m_dialogueManager: {fileID: 603229846}
 --- !u!1 &1076571786
 GameObject:
@@ -7636,7 +7637,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2749643000905583481, guid: 98082c22b951c4cf5879c5cc584d9e35, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -0.000061035156
       objectReference: {fileID: 0}
     - target: {fileID: 2774215032440526516, guid: 98082c22b951c4cf5879c5cc584d9e35, type: 3}
       propertyPath: m_AnchorMax.y
@@ -7672,7 +7673,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3222788607126687445, guid: 98082c22b951c4cf5879c5cc584d9e35, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -0.00012207031
       objectReference: {fileID: 0}
     - target: {fileID: 3421771721581367499, guid: 98082c22b951c4cf5879c5cc584d9e35, type: 3}
       propertyPath: m_AnchorMax.y
@@ -9304,7 +9305,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3150507626920306536, guid: 94fffc5c8c7f44184891585667852248, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000034332275
+      value: -0.00007200241
       objectReference: {fileID: 0}
     - target: {fileID: 6831887376889086760, guid: 94fffc5c8c7f44184891585667852248, type: 3}
       propertyPath: m_Pivot.x
@@ -12978,7 +12979,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6294589840691571660}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
@@ -13915,7 +13916,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8703905633543091152, guid: 5ba3600001feb49078ad9ccf3e63c485, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -0.000061035156
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -13993,19 +13994,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 24807720158041452, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 24807720158041452, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 24807720158041452, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 24807720158041452, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 68718549288798903, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
@@ -14109,51 +14110,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1562104221148301797, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1562104221148301797, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1562104221148301797, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1562104221148301797, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1774235970409251225, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1774235970409251225, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1774235970409251225, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1774235970409251225, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1953006884838882242, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1953006884838882242, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1953006884838882242, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1953006884838882242, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2687250272157844871, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_Location
@@ -14273,19 +14274,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3819503985254703424, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3819503985254703424, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3819503985254703424, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3819503985254703424, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3912656416303952967, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_Name
@@ -14297,19 +14298,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3984628041091976341, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3984628041091976341, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3984628041091976341, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3984628041091976341, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4270740151023247255, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
@@ -14337,51 +14338,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4432901087492667055, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4432901087492667055, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4432901087492667055, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4432901087492667055, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4744121756294525588, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4744121756294525588, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4744121756294525588, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4744121756294525588, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4871528304704855873, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4871528304704855873, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4871528304704855873, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4871528304704855873, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5005612119327363043, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.x
@@ -14421,19 +14422,19 @@ PrefabInstance:
       objectReference: {fileID: 583202541684043457}
     - target: {fileID: 5412882003471845550, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5412882003471845550, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5412882003471845550, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5412882003471845550, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5681683905889119440, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_Name
@@ -14489,19 +14490,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7149193992273721316, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7149193992273721316, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7149193992273721316, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7149193992273721316, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7336970284872990531, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
@@ -14545,35 +14546,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7890525245257057731, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7890525245257057731, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7890525245257057731, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7890525245257057731, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7927995312181673880, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7927995312181673880, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7927995312181673880, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7927995312181673880, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7987566784817992072, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.x
@@ -14617,19 +14618,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8557575899897080685, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8557575899897080685, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8557575899897080685, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 218
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8557575899897080685, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8559713778750966960, guid: 4e603b251e3934f7681e6b9bb34c0fd0, type: 3}
       propertyPath: m_Location

--- a/Assets/Scripts/Constants/DateLabelConstants.cs
+++ b/Assets/Scripts/Constants/DateLabelConstants.cs
@@ -20,6 +20,16 @@ namespace Academical
             {6, "Final Lab Meeting of Term"}
         };
 
+        public static readonly Dictionary<int, string> DayStartStorylets = new Dictionary<int, string>
+        {
+            {1, "day1"},
+            {2, "day2"},
+            {3, "day3"},
+            {4, "day4"},
+            {5, "day5"},
+            {6, "day6"}
+        };
+
         public static string GetLabelForDay(int dateNum)
         {
             string dateLabel = "No Label Found.";
@@ -27,7 +37,18 @@ namespace Academical
             {
                 dateLabel = DayLabels[dateNum];
             }
-            return dateLabel;    
+            return dateLabel;
+
+        }
+        
+        public static string GetStoryletForDayStart(int dateNum)
+        {
+            string storylet = null;
+            if ( DayStartStorylets.ContainsKey( dateNum ) )
+            {
+                storylet = DayStartStorylets[dateNum];
+            }
+            return storylet;
 
         }
     }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -43,6 +43,12 @@ namespace Academical
 		private SocialEngineController m_socialEngine;
 
 		/// <summary>
+		/// Manages when/how the background overlay is displayed.
+		/// </summary>
+		[SerializeField]
+		private GameObject m_backgroundOverlay;
+
+		/// <summary>
 		/// A reference to the script controlling the dialogue and story progression.
 		/// </summary>
 		[SerializeField]
@@ -246,9 +252,6 @@ namespace Academical
 		{
 			GameEvents.OnStoryStart?.Invoke();
 
-			// This should not be hard coded, but we only have one level.
-			DialogueEvents.CharacterShown?.Invoke( "Bronislav", "right", "" );
-
 			if ( DataPersistenceManager.SaveData == null )
 			{
 				if ( m_dialogueManager.Story.StoryletExists( "start" ) )
@@ -266,6 +269,13 @@ namespace Academical
 		/// <param name="tags"></param>
 		public void SetPlayerLocation(string locationID, bool runStorylets = true)
 		{
+			//TODO: This is a hacky fix to existing broken code. We should eventually refactor/design the overlay entirely.
+			//If this is the first time we are moving to a location, update alpha to 1. 
+			if ( m_backgroundOverlay.GetComponent<CanvasGroup>().alpha == 0 )
+			{
+				m_backgroundOverlay.GetComponent<CanvasGroup>().alpha = 1;
+			}
+
 			Location location = m_simulationController.GetLocation( locationID );
 
 			if ( m_Player.Location != location )

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -423,9 +423,28 @@ namespace Academical
 			int nextDayNum = m_simulationController.DateTime.Day + 1;
 			string dateLabel = DateLabelConstants.GetLabelForDay( nextDayNum );
 
-			m_simulationController.AdvanceToNextDay(dateLabel);
+			m_simulationController.AdvanceToNextDay( dateLabel );
 
 			GameEvents.OnDayAdvanced?.Invoke( m_simulationController.DateTime.Day );
+
+			//Auto-start next day of content
+			TriggerNextDayDialogue( nextDayNum );
+			
+		}
+
+		private void TriggerNextDayDialogue(int dayNum)
+		{
+			string storyletName = DateLabelConstants.GetStoryletForDayStart( dayNum );
+			if ( storyletName == null )
+			{
+				throw new Exception( "Invalid day/storylet provided for Day Start!" );
+			}
+			else
+			{
+				Storylet dayStartStorylet = m_dialogueManager.Story.GetStorylet( storyletName );
+				m_dialogueManager.RunStorylet( dayStartStorylet );
+			}
+
 		}
 
 

--- a/Assets/Scripts/Managers/SpeakerSpriteManager.cs
+++ b/Assets/Scripts/Managers/SpeakerSpriteManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Anansi;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Academical
@@ -79,6 +80,17 @@ namespace Academical
 				Debug.LogWarning( $"Failed to show character {name}. Character already showing" );
 				return;
 			}
+
+			//Because this is an async, we need to guarantee all other characters in the position are hidden.
+			foreach ( KeyValuePair<string, CharacterSprite> otherCharacter in m_Characters )
+			{
+				if ( otherCharacter.Value.Position == position && otherCharacter.Key != characterName )
+				{
+					otherCharacter.Value.Hide();
+				}
+			}
+			
+
 
 			character.SetSprite( spriteTags );
 			character.Show( position );

--- a/Assets/Scripts/UI/DateLocationHudUI.cs
+++ b/Assets/Scripts/UI/DateLocationHudUI.cs
@@ -32,7 +32,14 @@ namespace Academical
 
 		public void UpdateLocation()
 		{
-			m_LocationTextMesh.text = m_GameManager.Player.Location.DisplayName;
+			if ( m_GameManager.Player.Location != null )
+			{
+				m_LocationTextMesh.text = m_GameManager.Player.Location.DisplayName;
+			}
+			else
+			{ 
+				m_LocationTextMesh.text = "";
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

This PR covers adding in support for "day intros" that occur whenever a new day starts. This feature is necessary because the game starts without context and is confusing without information on what is happening in the day/timeline. This accomplishes this by extending our day constants file and utilizing it to grab pre-determined storylets (no sifting is necessary with these) whenever a new day is advanced. Smaller bugs are fixed throughout, and content is added to the first day to add a tutorial and flesh out the introductory scene.

# Summary of changes

- Ink files for days 1-6
- Start knot will now automatically trigger day1 ink file
- New functions in game manager to support fetching/starting day ink files on advance day
- Extended day constants to have a storylet name lookup
- Fixed display bugs caused by unnecessary async show/hide of characters - all characters sharing a single position are now hidden before attempting to show a new one
- Updated background overlay so that characters can be rendered without color distortion when no location background is present (needed for introductory scene)